### PR TITLE
Use relative path for test-framework

### DIFF
--- a/test/suite.wren
+++ b/test/suite.wren
@@ -1,4 +1,4 @@
-import "test-framework" for Expect, Suite, ConsoleReporter
+import "./test-framework" for Expect, Suite, ConsoleReporter
 import "../pure" for Pure
 
 var TestPure = Suite.new("Pure") { |it|


### PR DESCRIPTION
This fixes the test framework for the latest wren_cli.